### PR TITLE
Fix _format_genre and _list2str methods

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "html.format.wrapLineLength": 120,
+    "pylint.args": ["--max-line-length=140"]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,16 @@ RUN set -eux; \
 	ln -s /opt/bats/bin/bats /usr/local/bin/bats; \
 	rm -rf /tmp/bats-core-$BATS_VERSION
 
+# Install beets patch + yt-dlp upgrade
+RUN set -eux; \
+	BUILD_DEPS='git'; \
+	apk add --update --no-cache $BUILD_DEPS; \
+	python3 -m pip install \
+		git+https://github.com/beetbox/beets.git@a1c0ebdeef267e227c26f9defc93799c86c8fe54#egg=beets \
+		ytmusicapi==1.9.1 \
+		yt-dlp==2025.01.26; \
+	apk del --purge $BUILD_DEPS
+
 # Install beets-autogenre from source
 COPY dist /plugin/dist
 RUN python -m pip install /plugin/dist/*

--- a/beetsplug/autogenre/__init__.py
+++ b/beetsplug/autogenre/__init__.py
@@ -330,7 +330,7 @@ class AutoGenrePlugin(BeetsPlugin):
         return self._genre_tree
 
     def _format_genre(self, genre):
-        return self._lastgenre._format_tag(genre)
+        return genre.title() if self._lastgenre_conf.get("title_case") else genre
 
     def _str2list(self, str):
         return str and str.split(self._separator) or []

--- a/beetsplug/autogenre/__init__.py
+++ b/beetsplug/autogenre/__init__.py
@@ -330,6 +330,7 @@ class AutoGenrePlugin(BeetsPlugin):
         return self._genre_tree
 
     def _format_genre(self, genre):
+        print("THIS IS WHAT title_case OPTION IS:", self._lastgenre_conf.get("title_case") )
         return genre.title() if self._lastgenre_conf.get("title_case") else genre
 
     def _str2list(self, str):

--- a/beetsplug/autogenre/__init__.py
+++ b/beetsplug/autogenre/__init__.py
@@ -336,7 +336,9 @@ class AutoGenrePlugin(BeetsPlugin):
         return str and str.split(self._separator) or []
 
     def _list2str(self, genrelist):
-        return self._separator.join([str(g) for g in genrelist if g is not None])
+        max_count = self._lastgenre_conf["count"]
+        genres = genrelist[:max_count]
+        return self._separator.join([self._format_genre(str(g)) for g in genres if g is not None])
 
 
 def _filter_item(item, all, force):

--- a/beetsplug/autogenre/__init__.py
+++ b/beetsplug/autogenre/__init__.py
@@ -335,8 +335,8 @@ class AutoGenrePlugin(BeetsPlugin):
     def _str2list(self, str):
         return str and str.split(self._separator) or []
 
-    def _list2str(self, list):
-        return self._separator.join(list)
+    def _list2str(self, genrelist):
+        return self._separator.join([str(g) for g in genrelist if g is not None])
 
 
 def _filter_item(item, all, force):


### PR DESCRIPTION
Since I patched out `_format_tags` recently in beets' lastgenre plugin I implement it here.

Also I found that sometimes I get Nonetype genres. I ensured `_list2str` can handle them.

Closes #5